### PR TITLE
Add config sync to hide author & ts on webform nodes

### DIFF
--- a/config/optional/node.type.webform.yml
+++ b/config/optional/node.type.webform.yml
@@ -1,0 +1,22 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - menu_ui
+  enforced:
+    module:
+      - webform_node
+third_party_settings:
+  menu_ui:
+    available_menus:
+      - main
+    parent: 'main:'
+_core:
+  default_config_hash: BuY_3PjmYtRTSuvyFORJZUe0-TQiNXEE6yYQ_dkjxW8
+name: Webform
+type: webform
+description: 'A basic page with a webform attached.'
+help: ''
+new_revision: false
+preview_mode: 1
+display_submitted: false


### PR DESCRIPTION
Webform nodes annoyingly display a 'Submitted by username on timestamp' string above the webform, which is both confusing and useless.

This config hides that string.

closes #1